### PR TITLE
Warning Banner shows when private stream unsubscribed

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -894,6 +894,7 @@ export function save_discard_widget_status_handler(
     change_save_button_state($save_btn_controls, button_state);
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     // const $subBtn = $element.find(".subscribe-button");
 
     // if (state !== "saving") {
@@ -911,6 +912,8 @@ export function save_discard_widget_status_handler(
 
 =======
 >>>>>>> parent of 09e53b0686 (if priv and unsub)
+=======
+>>>>>>> parent of 09e53b0686 (if priv and unsub)
     // If this widget is for a stream, and the stream isn't currently private
     // but being changed to private, and the user changing this setting isn't
     // subscribed, we show a warning that they won't be able to access the
@@ -918,6 +921,7 @@ export function save_discard_widget_status_handler(
     if (!sub) {
         return;
     }
+<<<<<<< HEAD
 <<<<<<< HEAD
     if (!sub.subscribed){
         if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
@@ -937,6 +941,8 @@ export function save_discard_widget_status_handler(
             $(render_compose_banner(context)),
         );
     }
+=======
+>>>>>>> parent of 09e53b0686 (if priv and unsub)
 =======
 >>>>>>> parent of 09e53b0686 (if priv and unsub)
     if (

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -893,6 +893,7 @@ export function save_discard_widget_status_handler(
     const button_state = show_change_process_button ? "unsaved" : "discarded";
     change_save_button_state($save_btn_controls, button_state);
 
+<<<<<<< HEAD
     // const $subBtn = $element.find(".subscribe-button");
 
     // if (state !== "saving") {
@@ -908,6 +909,8 @@ export function save_discard_widget_status_handler(
 
     // sub_button 
 
+=======
+>>>>>>> parent of 09e53b0686 (if priv and unsub)
     // If this widget is for a stream, and the stream isn't currently private
     // but being changed to private, and the user changing this setting isn't
     // subscribed, we show a warning that they won't be able to access the
@@ -915,6 +918,7 @@ export function save_discard_widget_status_handler(
     if (!sub) {
         return;
     }
+<<<<<<< HEAD
     if (!sub.subscribed){
         if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
             return;
@@ -933,6 +937,8 @@ export function save_discard_widget_status_handler(
             $(render_compose_banner(context)),
         );
     }
+=======
+>>>>>>> parent of 09e53b0686 (if priv and unsub)
     if (
         button_state === "unsaved" &&
         !sub.invite_only &&

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -127,6 +127,9 @@ export function get_property_value(
         if (property_name === "is_default_stream") {
             return stream_data.is_default_stream_id(sub.stream_id);
         }
+        // if (property_name === "subscribed") {
+        //     return true;
+        // }
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         return sub[property_name as keyof StreamSubscription];
     }
@@ -711,6 +714,19 @@ export function check_property_changed(
     ) as setting_property_type;
     let current_val = get_property_value(property_name, for_realm_default_settings, sub, group);
     let proposed_val;
+    
+    if (sub) {
+        if (!sub.subscribed) {
+            return true;
+        }
+    }
+    
+
+    // const currentSubscribed = sub ? sub.subscribed : false;
+
+    // if (!prevSubscribed) {
+    //     return true;  // Return true if subscription status changes
+    // }
 
     switch (property_name) {
         case "realm_authentication_methods":
@@ -757,13 +773,18 @@ export function check_property_changed(
             proposed_val = get_input_element_value(elem, "radio-group");
             break;
         default:
-            if (current_val !== undefined) {
-                proposed_val = get_input_element_value(elem, typeof current_val);
-            } else {
-                blueslip.error("Element refers to unknown property", {property_name});
+            // if (current_val !== undefined) {
+            //     proposed_val = get_input_element_value(elem, typeof current_val);
+            // } else {
+            //     blueslip.error("Element refers to unknown property", {property_name});
+            // }
+            proposed_val = get_input_element_value(elem, typeof current_val);
+            if (current_val !== proposed_val) {
+                return true;
             }
     }
-    return current_val !== proposed_val;
+    // return current_val !== proposed_val;
+    return false;
 }
 
 function switching_to_private(
@@ -781,6 +802,39 @@ function switching_to_private(
     }
     return false;
 }
+
+function checkIfUnsubscribed(properties_elements: HTMLElement[], for_realm_default_settings: boolean, sub: StreamSubscription | undefined): boolean {
+    // Early exit if the subscription object is undefined or already unsubscribed
+    if (!sub || !sub.subscribed) {
+        return true;  // Indicates that the user is not subscribed
+    }
+
+    // Assuming there's an element or way to determine the 'active' subscription state
+    // This loop might not be necessary if you're directly checking `sub.subscribed`
+    for (const elem of properties_elements) {
+        const $elem = $(elem);
+        const property_name = extract_property_name($elem, for_realm_default_settings);
+        if (property_name === "subscribed") {
+            const currentSubscribed = get_input_element_value(elem, "checkbox"); // Assuming subscription status is a checkbox
+            return !currentSubscribed;  // Check if the checkbox is unchecked
+        }
+    }
+    return false;
+
+    // const $saveBtn = $element.find(".subscribe-button");
+}
+
+function isUnsubscribed($element: JQuery): boolean {
+    const $subscribeButton = $element.find(".subscribe-button");
+    if ($subscribeButton.hasClass("unsubscribed")) {
+    // if (state === "Subscribe") {
+        // If the state is "Subscribe", the user is unsubscribed.
+        return true;
+    } else {
+        return false;
+    }
+}
+
 
 export function change_sub_button_state($element: JQuery, state: string): void {
     function show_hide_element(
@@ -893,8 +947,6 @@ export function save_discard_widget_status_handler(
     const button_state = show_change_process_button ? "unsaved" : "discarded";
     change_save_button_state($save_btn_controls, button_state);
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     // const $subBtn = $element.find(".subscribe-button");
 
     // if (state !== "saving") {
@@ -910,10 +962,6 @@ export function save_discard_widget_status_handler(
 
     // sub_button 
 
-=======
->>>>>>> parent of 09e53b0686 (if priv and unsub)
-=======
->>>>>>> parent of 09e53b0686 (if priv and unsub)
     // If this widget is for a stream, and the stream isn't currently private
     // but being changed to private, and the user changing this setting isn't
     // subscribed, we show a warning that they won't be able to access the
@@ -921,35 +969,34 @@ export function save_discard_widget_status_handler(
     if (!sub) {
         return;
     }
-<<<<<<< HEAD
-<<<<<<< HEAD
-    if (!sub.subscribed){
-        if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
-            return;
-        }
-        const context = {
-            banner_type: compose_banner.WARNING,
-            banner_text: $t({
-                defaultMessage:
-                    "Only subscribers can access or join private streams, so you will lose access to this stream if you convert it to a private stream while not subscribed to it.",
-            }),
-            button_text: $t({defaultMessage: "Subscribe"}),
-            classname: "stream_privacy_warning",
-            stream_id: sub.stream_id,
-        };
-        $("#stream_permission_settings .stream-permissions-warning-banner").append(
-            $(render_compose_banner(context)),
-        );
-    }
-=======
->>>>>>> parent of 09e53b0686 (if priv and unsub)
-=======
->>>>>>> parent of 09e53b0686 (if priv and unsub)
+    
+    // const $sub_btn_controls = $subsection.find(".stream_settings_header .button-group");
+
+    // if (isUnsubscribed($sub_btn_controls)){
+    // if (!sub.subscribed){    
+    //     if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
+    //         return;
+    //     }
+    //     const context = {
+    //         banner_type: compose_banner.WARNING,
+    //         banner_text: $t({
+    //             defaultMessage:
+    //                 "Only subscribers can access or join private streams, so you will lose access to this stream if you convert it to a private stream while not subscribed to it.",
+    //         }),
+    //         button_text: $t({defaultMessage: "Subscribe"}),
+    //         classname: "stream_privacy_warning",
+    //         stream_id: sub.stream_id,
+    //     };
+    //     $("#stream_permission_settings .stream-permissions-warning-banner").append(
+    //         $(render_compose_banner(context)),
+    //     );
+    // // }
     if (
         button_state === "unsaved" &&
         !sub.invite_only &&
         !sub.subscribed &&
         switching_to_private(properties_elements, for_realm_default_settings)
+        // !sub.subscribed
     ) {
         if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
             return;

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -829,6 +829,7 @@ export function save_discard_widget_status_handler(
     } else {
         $("#stream_permission_settings .stream-permissions-warning-banner").empty();
     }
+    
     // if (
     //     button_state === "unsaved" &&
     //     !sub.invite_only &&

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -799,6 +799,9 @@ export function save_discard_widget_status_handler(
     const button_state = show_change_process_button ? "unsaved" : "discarded";
     change_save_button_state($save_btn_controls, button_state);
 
+    const isChangingToPrivate = switching_to_private(properties_elements, for_realm_default_settings);
+    const isPrivateAndUnsubscribing = sub && sub.invite_only && !sub.subscribed;
+
     // If this widget is for a stream, and the stream isn't currently private
     // but being changed to private, and the user changing this setting isn't
     // subscribed, we show a warning that they won't be able to access the
@@ -806,12 +809,7 @@ export function save_discard_widget_status_handler(
     if (!sub) {
         return;
     }
-    if (
-        button_state === "unsaved" &&
-        !sub.invite_only &&
-        !sub.subscribed &&
-        switching_to_private(properties_elements, for_realm_default_settings)
-    ) {
+    if (sub && (button_state === "unsaved" && isChangingToPrivate || isPrivateAndUnsubscribing)) {
         if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
             return;
         }
@@ -831,6 +829,31 @@ export function save_discard_widget_status_handler(
     } else {
         $("#stream_permission_settings .stream-permissions-warning-banner").empty();
     }
+    // if (
+    //     button_state === "unsaved" &&
+    //     !sub.invite_only &&
+    //     !sub.subscribed &&
+    //     switching_to_private(properties_elements, for_realm_default_settings)
+    // ) {
+    //     if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
+    //         return;
+    //     }
+    //     const context = {
+    //         banner_type: compose_banner.WARNING,
+    //         banner_text: $t({
+    //             defaultMessage:
+    //                 "Only subscribers can access or join private streams, so you will lose access to this stream if you convert it to a private stream while not subscribed to it.",
+    //         }),
+    //         button_text: $t({defaultMessage: "Subscribe"}),
+    //         classname: "stream_privacy_warning",
+    //         stream_id: sub.stream_id,
+    //     };
+    //     $("#stream_permission_settings .stream-permissions-warning-banner").append(
+    //         $(render_compose_banner(context)),
+    //     );
+    // } else {
+    //     $("#stream_permission_settings .stream-permissions-warning-banner").empty();
+    // }
 }
 
 function check_maximum_valid_value(

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -879,7 +879,11 @@ export function register_save_discard_widget_handlers(
         // they do, we transition to the "unsaved" state showing the
         // save/discard widget; otherwise, we hide that widget (the
         // "discarded" state).
-
+        if (sub) {
+            if (!sub.subscribed) {
+                return true;
+            }
+        }
         if ($(e.target).hasClass("no-input-change-detection")) {
             // This is to prevent input changes detection in elements
             // within a subsection whose changes should not affect the

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -4,6 +4,9 @@ import tippy from "tippy.js";
 import render_announce_stream_checkbox from "../templates/stream_settings/announce_stream_checkbox.hbs";
 import render_stream_privacy_icon from "../templates/stream_settings/stream_privacy_icon.hbs";
 import render_stream_settings_tip from "../templates/stream_settings/stream_settings_tip.hbs";
+import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
+import * as compose_banner from "./compose_banner";
+import { save_discard_widget_status_handler } from './settings_components';
 
 import * as hash_parser from "./hash_parser";
 import {$t} from "./i18n";
@@ -135,10 +138,30 @@ export function initialize_cant_subscribe_popover() {
 }
 
 export function set_up_right_panel_section(sub) {
+
     if (sub.subscribed) {
         stream_edit_toggler.toggler.enable_tab("personal");
         stream_edit_toggler.toggler.goto(stream_edit_toggler.select_tab);
+        // $("#stream_permission_settings .stream-permissions-warning-banner").empty();
     } else {
+        // if (!sub.invite_only) {
+        //     if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
+        //         return;
+        //     }
+        //     const context = {
+        //         banner_type: compose_banner.WARNING,
+        //         banner_text: $t({
+        //             defaultMessage:
+        //                 "Only subscribers can access or join private streams, so you will lose access to this stream if you convert it to a private stream while not subscribed to it.",
+        //         }),
+        //         button_text: $t({defaultMessage: "Subscribe"}),
+        //         classname: "stream_privacy_warning",
+        //         stream_id: sub.stream_id,
+        //     };
+        //     $("#stream_permission_settings .stream-permissions-warning-banner").append(
+        //         $(render_compose_banner(context)),
+        //     );
+        // }
         if (stream_edit_toggler.select_tab === "personal") {
             // Go to the general settings tab, if the user is not
             // subscribed. Also preserve the previous selected tab,
@@ -156,7 +179,29 @@ export function update_toggler_for_sub(sub) {
     if (!hash_parser.is_editing_stream(sub.stream_id)) {
         return;
     }
-
+    if (sub) {
+        if (!sub.subscribed &&
+            !sub.invite_only) {
+            if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
+                return;
+            }
+            const context = {
+                banner_type: compose_banner.WARNING,
+                banner_text: $t({
+                    defaultMessage:
+                        "Only subscribers can access or join private streams, so you will lose access to this stream if you convert it to a private stream while not subscribed to it.",
+                }),
+                button_text: $t({defaultMessage: "Subscribe"}),
+                classname: "stream_privacy_warning",
+                stream_id: sub.stream_id,
+            };
+            $("#stream_permission_settings .stream-permissions-warning-banner").append(
+                $(render_compose_banner(context)),
+            );
+        } else {
+            $("#stream_permission_settings .stream-permissions-warning-banner").empty();
+        }
+    }
     set_up_right_panel_section(sub);
 }
 


### PR DESCRIPTION
Warning Banner now pops up when private stream goes from subscribed to unsubscribed. Banner also disappears when on public stream or no longer actionable.

Fixes: From Zulip Issue [#29625](https://github.com/zulip/zulip/issues/29625). Fixed banner not showing up when private stream is unsubscribed from.


https://github.com/zulip/zulip/assets/113942816/ec5aebaf-1140-4dd3-ba41-7eacc041e0e7